### PR TITLE
Increase disk_quota to 50m in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: go-concourse-summary
   memory: 20M
-  disk_quota: 20M
+  disk_quota: 50M
   instances: 2
   env:
     GOVERSION: go1.9


### PR DESCRIPTION
20m wasn't quite enough to install vendored packages when using
go_buildpack, and it failed during push. The instance requires at least 50m