### PR TITLE
Use single app definition in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: go-concourse-summary
   memory: 20M
-  disk_quota: 20M
+  disk_quota: 50M
   instances: 2
   env:
     GOVERSION: go1.9

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,8 @@
 ---
-applications:
-- name: go-concourse-summary
-  memory: 20M
-  disk_quota: 50M
-  instances: 2
-  env:
-    GOVERSION: go1.9
-    GOPACKAGENAME: github.com/FidelityInternational/go-concourse-summary
+name: go-concourse-summary
+memory: 20M
+disk_quota: 50M
+instances: 2
+env:
+  GOVERSION: go1.9
+  GOPACKAGENAME: github.com/FidelityInternational/go-concourse-summary


### PR DESCRIPTION
**IMPORTANT**: Merge the PR #1 first

The manifest only refers to one application, go-concourse-summary,
and there is no need to use the syntax to describe multiple
applications[1]

Additionally, we want to use cf-cli-resoure concourse resource[2] to
deploy the application, but it only supports the old single instance
format for some features, like modify environment variables.

[1] https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html
[2] https://github.com/patrickcrocker/cf-cli-resource
