### PR TITLE
Increase disk quota to 70m

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 name: go-concourse-summary
 memory: 40M
-disk_quota: 50M
+disk_quota: 70M
 instances: 2
 env:
   GOVERSION: go1.9


### PR DESCRIPTION
Possibly a change in use of the go-buildpack has tipped the deployment
slightly over the edge of 50m. Upping to 70m to create a bit of
headroom.

Signed-off-by: Chris Metcalf <christopher.metcalf@fil.com>