### PR TITLE
FIX: go-concourse-summary fails to link to the underlying group.

### DIFF
--- a/concourse/data.go
+++ b/concourse/data.go
@@ -86,7 +86,7 @@ func getData(host string, config *Config) ([]Data, error) {
 					if group == "" {
 						datum.URL = fmt.Sprintf("%s%s", webURI, pipeline.Name)
 					} else {
-						datum.URL = fmt.Sprintf("%s%s?groups=%s", webURI, pipeline.URL, group)
+						datum.URL = fmt.Sprintf("%s%s?groups=%s", webURI, pipeline.Name, group)
 					}
 				}
 				if !datum.Running {

--- a/concourse/data.go
+++ b/concourse/data.go
@@ -56,6 +56,7 @@ func filterData(data []Data, pipelines []Pipeline) []Data {
 
 func getData(host string, config *Config) ([]Data, error) {
 	uri := fmt.Sprintf("%s://%s", config.Protocol, host)
+	webURI := uri + "/teams/" + config.Team + "/pipelines/"
 	httpClient := createHTTPClient(config)
 	client := concourse.NewClient(uri, httpClient, false)
 	team := client.Team(config.Team)
@@ -83,9 +84,9 @@ func getData(host string, config *Config) ([]Data, error) {
 					datum.Group = group
 					datum.Paused = pipeline.Paused
 					if group == "" {
-						datum.URL = fmt.Sprintf("%s%s", uri, pipeline.URL)
+						datum.URL = fmt.Sprintf("%s%s", webURI, pipeline.Name)
 					} else {
-						datum.URL = fmt.Sprintf("%s%s?groups=%s", uri, pipeline.URL, group)
+						datum.URL = fmt.Sprintf("%s%s?groups=%s", webURI, pipeline.URL, group)
 					}
 				}
 				if !datum.Running {

--- a/concourse/pipeline_with_groups_fixture_test.go
+++ b/concourse/pipeline_with_groups_fixture_test.go
@@ -1,0 +1,91 @@
+package summary_test
+
+const examplePipeline = `[
+    {
+        "id": 2,
+        "name": "cf-example-pipeline",
+        "paused": false,
+        "public": true,
+        "groups": [
+            {
+                "name": "test-group",
+                "jobs": [
+                    "testJob1",
+                    "testJob2"
+                ]
+            }
+        ],
+        "team_name": "main"
+    }
+]`
+
+const examplePipelineJobs = `[
+    {
+        "id": 695,
+        "name": "testJob1",
+        "pipeline_name": "cf-example-pipeline",
+        "team_name": "main",
+        "next_build": null,
+        "finished_build": {
+            "id": 691532,
+            "team_name": "main",
+            "name": "4",
+            "status": "succeeded",
+            "job_name": "testJob1",
+            "api_url": "/api/v1/builds/691532",
+            "pipeline_name": "cf-example-pipeline",
+            "start_time": 1525965370,
+            "end_time": 1525965398
+        },
+        "inputs": [
+            {
+                "name": "testInput1",
+                "resource": "testResource1",
+                "trigger": false
+            },
+            {
+                "name": "testInput2",
+                "resource": "testResoure2",
+                "trigger": false
+            }
+        ],
+        "outputs": [],
+        "groups": [
+            "test-group"
+        ]
+    },
+    {
+        "id": 696,
+        "name": "testJob1",
+        "pipeline_name": "cf-example-pipeline",
+        "team_name": "main",
+        "next_build": null,
+        "finished_build": {
+            "id": 691297,
+            "team_name": "main",
+            "name": "5",
+            "status": "succeeded",
+            "job_name": "testJob1",
+            "api_url": "/api/v1/builds/691297",
+            "pipeline_name": "cf-example-pipeline",
+            "start_time": 1525965125,
+            "end_time": 1525965137
+        },
+        "inputs": [
+            {
+                "name": "testInput1",
+                "resource": "testResource1",
+                "trigger": false
+            },
+            {
+                "name": "testInput2",
+                "resource": "testResource2",
+                "trigger": false
+            }
+        ],
+        "outputs": [],
+        "groups": [
+            "test-group"
+        ]
+    }
+]`

--- a/concourse/summary_test.go
+++ b/concourse/summary_test.go
@@ -428,6 +428,7 @@ var _ = Describe("#HostSummary", func() {
 		config       = &summary.Config{
 			Templates: templates,
 			Protocol:  "http",
+			Team:      "main",
 		}
 	)
 
@@ -439,6 +440,7 @@ var _ = Describe("#HostSummary", func() {
 		config = &summary.Config{
 			Templates: templates,
 			Protocol:  "http",
+			Team:      "main",
 		}
 	})
 
@@ -452,7 +454,7 @@ var _ = Describe("#HostSummary", func() {
 	Context("when concourse returns invalid json", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", "[}", 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", "[}", 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -466,7 +468,7 @@ var _ = Describe("#HostSummary", func() {
 	Context("when concourse has no pipelines", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", "[]", 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", "[]", 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -507,8 +509,8 @@ var _ = Describe("#HostSummary", func() {
 	Context("and concourse has pipelines", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", pipelinesPayload, 200, "", nil},
-				{"GET", "/api/v1/teams/pipelines/test1/jobs", jobsPayload, 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", pipelinesPayload, 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines/test1/jobs", jobsPayload, 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -537,7 +539,7 @@ var _ = Describe("#HostSummary", func() {
 <div class="scalable">
 
 
-	<a href="http://127.0.0.1:49898/test1.url" target="_blank" class="outer">
+	<a href="http://127.0.0.1:49898/teams/main/pipelines/test1" target="_blank" class="outer">
 	<div class="status">
 		<div class="paused_job" style="width: 0%;"></div>
 		<div class="aborted" style="width: 16%;"></div>
@@ -569,6 +571,7 @@ var _ = Describe("#GroupSummary", func() {
 		config       = &summary.Config{
 			Templates: templates,
 			Protocol:  "http",
+			Team:      "main",
 		}
 	)
 
@@ -580,6 +583,7 @@ var _ = Describe("#GroupSummary", func() {
 		config = &summary.Config{
 			Templates: templates,
 			Protocol:  "http",
+			Team:      "main",
 		}
 	})
 
@@ -604,7 +608,7 @@ var _ = Describe("#GroupSummary", func() {
 	Context("when concourse returns invalid json", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", "[}", 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", "[}", 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -618,7 +622,7 @@ var _ = Describe("#GroupSummary", func() {
 	Context("when concourse has no pipelines", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", "[]", 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", "[]", 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -664,8 +668,8 @@ var _ = Describe("#GroupSummary", func() {
 	Context("and concourse has pipelines", func() {
 		BeforeEach(func() {
 			mocks := []MockRoute{
-				{"GET", "/api/v1/teams/pipelines", pipelinesPayload, 200, "", nil},
-				{"GET", "/api/v1/teams/pipelines/test1/jobs", jobsPayload, 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines", pipelinesPayload, 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines/test1/jobs", jobsPayload, 200, "", nil},
 			}
 			setupMultiple(mocks)
 		})
@@ -697,7 +701,7 @@ var _ = Describe("#GroupSummary", func() {
   <div>
 
 
-  <a href="http://127.0.0.1:53555/test1.url" target="_blank" class="outer">
+  <a href="http://127.0.0.1:53555/teams/main/pipelines/test1" target="_blank" class="outer">
   <div class="status">
     <div class="paused_job" style="width: 0%;"></div>
     <div class="aborted" style="width: 16%;"></div>

--- a/concourse/summary_test.go
+++ b/concourse/summary_test.go
@@ -223,19 +223,24 @@ var _ = Describe("#SetupConfig", func() {
 	})
 })
 
+func buildConfig(templates *template.Template, team string, protocol string) *summary.Config {
+	config := summary.Config{
+		Templates: templates,
+		Team:      team,
+		Protocol:  protocol,
+	}
+	return &config
+}
+
 var _ = Describe("config#Index", func() {
 	var (
 		templates    = template.Must(template.ParseGlob("../templates/*"))
 		mockRecorder *httptest.ResponseRecorder
-		config       = &summary.Config{
-			Templates: templates,
-		}
+		config       = buildConfig(templates, "", "")
 	)
 
 	AfterEach(func() {
-		config = &summary.Config{
-			Templates: templates,
-		}
+		config = buildConfig(templates, "", "")
 	})
 
 	JustBeforeEach(func() {
@@ -425,11 +430,7 @@ var _ = Describe("#HostSummary", func() {
 	var (
 		templates    = template.Must(template.ParseGlob("../templates/*"))
 		mockRecorder *httptest.ResponseRecorder
-		config       = &summary.Config{
-			Templates: templates,
-			Protocol:  "http",
-			Team:      "main",
-		}
+		config       = buildConfig(templates, "main", "http")
 	)
 
 	AfterEach(func() {
@@ -437,11 +438,7 @@ var _ = Describe("#HostSummary", func() {
 			teardown()
 		}
 
-		config = &summary.Config{
-			Templates: templates,
-			Protocol:  "http",
-			Team:      "main",
-		}
+		config = buildConfig(templates, "main", "http")
 	})
 
 	JustBeforeEach(func() {
@@ -568,11 +565,7 @@ var _ = Describe("#GroupSummary", func() {
 	var (
 		templates    = template.Must(template.ParseGlob("../templates/*"))
 		mockRecorder *httptest.ResponseRecorder
-		config       = &summary.Config{
-			Templates: templates,
-			Protocol:  "http",
-			Team:      "main",
-		}
+		config       = buildConfig(templates, "main", "http")
 	)
 
 	AfterEach(func() {
@@ -580,11 +573,7 @@ var _ = Describe("#GroupSummary", func() {
 			teardown()
 		}
 
-		config = &summary.Config{
-			Templates: templates,
-			Protocol:  "http",
-			Team:      "main",
-		}
+		config = buildConfig(templates, "main", "http")
 	})
 
 	JustBeforeEach(func() {

--- a/concourse/summary_test.go
+++ b/concourse/summary_test.go
@@ -715,4 +715,66 @@ var _ = Describe("#GroupSummary", func() {
 </html>`)))))
 		})
 	})
+
+	Context("and concourse has a pipeline with groups", func() {
+		BeforeEach(func() {
+			mocks := []MockRoute{
+				{"GET", "/api/v1/teams/main/pipelines", examplePipeline, 200, "", nil},
+				{"GET", "/api/v1/teams/main/pipelines/cf-example-pipeline/jobs", examplePipelineJobs, 200, "", nil},
+			}
+			setupMultiple(mocks)
+		})
+
+		It("returns a page with status etc", func() {
+			Ω(mockRecorder.Code).Should(Equal(200))
+			Ω(stripHostPort(stripDate(stringMinifier(mockRecorder.Body.String())))).Should(Equal(stripHostPort(stripDate(stringMinifier(`
+<!DOCTYPE html>
+<html>
+  <head rel="v2">
+    <title>Concourse Summary</title>
+    <link rel="icon" type="image/png" href="/favicon.png" sizes="32x32">
+    <link rel="stylesheet" type="text/css" href="/styles.css">
+    <script>window.refresh_interval =  0 </script>
+    <script src="/favico-0.3.10.min.js"></script>
+    <script src="/refresh.js"></script>
+  </head>
+  <body>
+    <div class="time">
+      2017-09-13 09:38:03 &#43;0100 (<span id="countdown">0</span>)
+      <div class="right">
+        <a class="github" href="https://github.com/FidelityInternational/go-concourse-summary" target="_blank">&nbsp;</a>
+      </div>
+    </div>
+
+
+<div class="group">
+  <a href="/host/127.0.0.1:53555">127.0.0.1:53555</a>
+  <div>
+
+
+  <a href="http://127.0.0.1:53555/teams/main/pipelines/cf-example-pipeline?groups=test-group" target="_blank" class="outer">
+  <div class="status">
+    <div class="paused_job" style="width: 0%;"></div>
+    <div class="aborted" style="width: 0%;"></div>
+    <div class="errored" style="width: 0%;"></div>
+    <div class="failed" style="width: 0%;"></div>
+    <div class="succeeded" style="width: 100%;"></div>
+  </div>
+
+
+  <div class="inner">
+    <span class="cf-example-pipeline"><span>cf-example-pipeline</span></span>
+    <span class="test-group"><span>test-group</span></span>
+  </div>
+  </a>
+
+
+  </div>
+</div>
+
+
+  </body>
+</html>`)))))
+		})
+	})
 })


### PR DESCRIPTION
Concourse summary is currently failing to link correctly to the underlying group after upgrade to 3.11. concourse atc lib returns a pipeline object with a null URL which results in the pipeline section missing from the generated link. `https://<my-url>/?groups=<my-group>` instead of `https://<my-url>/teams/<my-team>/pipelines/<my-pipeline>?groups=<my-group>`

This PR changes the build of the webURI so that it looks as expected (and is a functioning link), test coverage has been added for this change. 