### PR TITLE
Update links for Concourse 5.x.x

### DIFF
--- a/concourse/data.go
+++ b/concourse/data.go
@@ -86,7 +86,7 @@ func getData(host string, config *Config) ([]Data, error) {
 					if group == "" {
 						datum.URL = fmt.Sprintf("%s%s", webURI, pipeline.Name)
 					} else {
-						datum.URL = fmt.Sprintf("%s%s?groups=%s", webURI, pipeline.Name, group)
+						datum.URL = fmt.Sprintf("%s%s?group=%s", webURI, pipeline.Name, group)
 					}
 				}
 				if !datum.Running {

--- a/concourse/summary_test.go
+++ b/concourse/summary_test.go
@@ -752,7 +752,7 @@ var _ = Describe("#GroupSummary", func() {
   <div>
 
 
-  <a href="http://127.0.0.1:53555/teams/main/pipelines/cf-example-pipeline?groups=test-group" target="_blank" class="outer">
+  <a href="http://127.0.0.1:53555/teams/main/pipelines/cf-example-pipeline?group=test-group" target="_blank" class="outer">
   <div class="status">
     <div class="paused_job" style="width: 0%;"></div>
     <div class="aborted" style="width: 0%;"></div>


### PR DESCRIPTION
When moving concourse 5.x.x the links to concourse were broken as the url has changed slightly.

- groups= has been changed to group=
- This is a breaking change for the links!