### PR TITLE
Bump golang version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,5 +4,5 @@ memory: 40M
 disk_quota: 70M
 instances: 2
 env:
-  GOVERSION: go1.11
+  GOVERSION: go1.12
   GOPACKAGENAME: github.com/FidelityInternational/go-concourse-summary


### PR DESCRIPTION
**WARNING** go 1.11.x will no longer be available in new buildpacks released after 2019-08-01.
See: https://golang.org/doc/devel/release.html